### PR TITLE
[Fix] 스톡몬 목록 조회 api 수정 #10

### DIFF
--- a/core/src/main/java/com/pda/core/controller/TravelerStockmonController.java
+++ b/core/src/main/java/com/pda/core/controller/TravelerStockmonController.java
@@ -1,7 +1,12 @@
 package com.pda.core.controller;
 
+import com.pda.commons.dto.SuccessResponse;
 import com.pda.core.dto.GetStockmonListResponseDto;
+import com.pda.core.dto.GetWorldStockmonsResponseDto;
 import com.pda.core.service.TravelerStockmonService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.Date;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,9 +22,20 @@ public class TravelerStockmonController {
     }
 
     @GetMapping("/stockmons")
-    public GetStockmonListResponseDto getStockmons() {
+    @Operation(summary = "모험가의 스톡몬 목록 조회")
+    public ResponseEntity<SuccessResponse<GetStockmonListResponseDto>> getStockmons() {
         // TODO: 추후 로그인 로직 추가시 수정
         long travelerId = 1;
-        return travelerStockmonService.getStockmonsByTravelerId(travelerId);
+        GetStockmonListResponseDto stockmons = travelerStockmonService.getStockmonsByTravelerId(travelerId);
+        return ResponseEntity.ok(SuccessResponse.<GetStockmonListResponseDto>builder()
+                .data(stockmons)
+                .message("성공")
+                .timestamp(new Date())
+                .build()
+        );
     }
+
+
+
+
 }

--- a/core/src/main/java/com/pda/core/dto/TravelerStockmonDto.java
+++ b/core/src/main/java/com/pda/core/dto/TravelerStockmonDto.java
@@ -1,16 +1,35 @@
 package com.pda.core.dto;
 
+import com.pda.core.entity.Stock;
+import com.pda.core.entity.Stockmon;
+import com.pda.core.entity.TravelerStockmon;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
+@Builder
 public class TravelerStockmonDto {
 
     private Long id;
     private String name;
     private String imgUrl;
-    private long count;
+    private Long count;
     private String stockCode;
     private Double stockAveragePrice;
+
+    public static TravelerStockmonDto fromEntity(TravelerStockmon travelerStockmon) {
+
+        Stockmon stockmon = travelerStockmon.getStockmon();
+        Stock stock = stockmon.getStock();
+
+        return TravelerStockmonDto.builder()
+                .id(stockmon.getId())
+                .name(stock.getName())
+                .imgUrl(stockmon.getImgUrl())
+                .count(travelerStockmon.getStockmonCount())
+                .stockCode(stock.getCode())
+                .stockAveragePrice(travelerStockmon.getStockmonAveragePrice())
+                .build();
+    }
+
 }

--- a/core/src/main/java/com/pda/core/entity/Account.java
+++ b/core/src/main/java/com/pda/core/entity/Account.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @AllArgsConstructor
-//@NoArgsConstructor
+@NoArgsConstructor
 public class Account {
 
     @Id
@@ -24,8 +24,5 @@ public class Account {
     @OneToMany(mappedBy = "account")
     @JsonIgnoreProperties("account")
     private List<AccountStock> accountStocks = new ArrayList<>();
-
-    public Account() {
-    }
 
 }

--- a/core/src/main/java/com/pda/core/entity/Region.java
+++ b/core/src/main/java/com/pda/core/entity/Region.java
@@ -1,7 +1,6 @@
 package com.pda.core.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -9,7 +8,6 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @Entity
 @Getter

--- a/core/src/main/java/com/pda/core/entity/StockTower.java
+++ b/core/src/main/java/com/pda/core/entity/StockTower.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @Entity
 @Getter

--- a/core/src/main/java/com/pda/core/entity/Stockmon.java
+++ b/core/src/main/java/com/pda/core/entity/Stockmon.java
@@ -43,5 +43,4 @@ public class Stockmon {
     @JsonIgnoreProperties("stockmon")
     private List<TravelerStockmon> trvelerStockmons = new ArrayList<>();
 
-
 }

--- a/core/src/main/java/com/pda/core/entity/Traveler.java
+++ b/core/src/main/java/com/pda/core/entity/Traveler.java
@@ -16,7 +16,6 @@ import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.grammars.hql.HqlParser.LocalDateTimeContext;
 
 @Entity
 @Getter

--- a/core/src/main/java/com/pda/core/entity/World.java
+++ b/core/src/main/java/com/pda/core/entity/World.java
@@ -1,6 +1,5 @@
 package com.pda.core.entity;
 
-
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -16,4 +15,5 @@ public class World {
     private final Boolean isCaught;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
+
 }

--- a/core/src/main/java/com/pda/core/service/TravelerStockmonService.java
+++ b/core/src/main/java/com/pda/core/service/TravelerStockmonService.java
@@ -29,40 +29,20 @@ public class TravelerStockmonService {
     }
 
 
-    // 특정 여행자의 모든 스톡몬 정보를 조회하는 메서드
     @Transactional
     public GetStockmonListResponseDto getStockmonsByTravelerId(Long travelerId) {
 
         List<TravelerStockmon> travelerStockmons = travelerStockmonRepository.findByTravelerId(travelerId);
 
-        List<TravelerStockmonDto> stockmonDtos = new ArrayList<>();
+        List<TravelerStockmonDto> travelerStockmonDtos = new ArrayList<>();
 
         for (TravelerStockmon travelerStockmon : travelerStockmons) {
-            TravelerStockmonDto dto = convertToTravelerStockmonDto(travelerStockmon);
-            stockmonDtos.add(dto);
+            TravelerStockmonDto dto = TravelerStockmonDto.fromEntity(travelerStockmon);
+            travelerStockmonDtos.add(dto);
         }
 
-        return new GetStockmonListResponseDto(stockmonDtos);
+        return new GetStockmonListResponseDto(travelerStockmonDtos);
 
     }
 
-    // TravelerStockmon 엔티티를 TravelerStockmonDto로 변환하는 메서드
-    private TravelerStockmonDto convertToTravelerStockmonDto(TravelerStockmon travelerStockmon) {
-
-        Stockmon stockmon = travelerStockmon.getStockmon();
-
-        Stock stock = stockmon.getStock();
-
-        TravelerStockmonDto dto = new TravelerStockmonDto();
-
-        // 4. TravelerStockmon, Stockmon, Stock 엔티티의 정보를 DTO에 설정
-        dto.setId(stockmon.getId());
-        dto.setName(stock.getName());
-        dto.setImgUrl(stockmon.getImgUrl());
-        dto.setCount(travelerStockmon.getStockmonCount());
-        dto.setStockCode(stock.getCode());
-        dto.setStockAveragePrice(travelerStockmon.getStockmonAveragePrice());
-
-        return dto;
-    }
 }


### PR DESCRIPTION

## 변경 사항 요약
> 요약 내용 나열 + (이미지)
- 응답 구조 맞추기 및 service에 있던 convertToTravelerStockmonDto를 fromEntity()로 분리 
![image](https://github.com/user-attachments/assets/bc62fdc9-c715-4063-86e7-7e4efb274ae2)


## 이슈 번호
- close #10 
