### PR TITLE
[FEAT] 맵 리젠과 생성 및 주변 맵 조회하는 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ allprojects {
 		implementation 'org.springframework.boot:spring-boot-starter-web'
 		implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 		implementation 'org.springframework.boot:spring-boot-starter-validation'
+		implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 		compileOnly 'org.projectlombok:lombok'
 
 		annotationProcessor 'org.projectlombok:lombok'

--- a/core/src/main/java/com/pda/core/CoreApplication.java
+++ b/core/src/main/java/com/pda/core/CoreApplication.java
@@ -2,8 +2,10 @@ package com.pda.core;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CoreApplication {
 
 	public static void main(String[] args) {

--- a/core/src/main/java/com/pda/core/config/RedisConfig.java
+++ b/core/src/main/java/com/pda/core/config/RedisConfig.java
@@ -1,0 +1,45 @@
+package com.pda.core.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // JSON 포맷으로 저장
+
+        redisTemplate.setConnectionFactory(connectionFactory);
+        return redisTemplate;
+    }
+
+    @Bean
+    public GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer(){
+        return new GenericJackson2JsonRedisSerializer();
+    }
+}

--- a/core/src/main/java/com/pda/core/controller/SwaggerTestController.java
+++ b/core/src/main/java/com/pda/core/controller/SwaggerTestController.java
@@ -1,38 +1,24 @@
 package com.pda.core.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pda.core.entity.World;
-import com.pda.core.service.RedisService;
+import com.pda.core.repository.RedisRepository;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.persistence.Access;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 // todo:  test 용 API 나중에 지우기
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api/test")
+@RequiredArgsConstructor
 public class SwaggerTestController {
 
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer;
-    private final ObjectMapper objectMapper;
-    private final RedisService redisService;
+    private final RedisRepository redisRepository;
+
 
     @GetMapping
     @Operation(summary = "테스트 API 입니다.")
@@ -41,13 +27,19 @@ public class SwaggerTestController {
     }
 
     @PostMapping("/set")
-    public String setValue(@RequestParam("key") String key, @RequestBody World world) throws JsonProcessingException {
-        redisService.pushToList(key, world);
+    public String setValue() throws JsonProcessingException {
+        List<World> list = new ArrayList<>();
+        for(int i = 0; i < 100000; i++) {
+            World world = new World(1L, 1.0, 1.0, 1L, false);
+            list.add(world);
+        }
+        redisRepository.setToListAll("heeeul", list);
         return "값 설정";
     }
 
     @GetMapping("/get")
     public List<Object> getValue(@RequestParam("key") String key) {
-        return redisService.getList(key);
+        return redisRepository.getList(key);
     }
+
 }

--- a/core/src/main/java/com/pda/core/controller/WorldController.java
+++ b/core/src/main/java/com/pda/core/controller/WorldController.java
@@ -35,14 +35,14 @@ public class WorldController {
 
     @PostMapping("/stockmons")
     @Operation(summary = "주변 스톡몬, 스톡타워 조회")
-    public ResponseEntity<SuccessResponse<GetWorldStockmonsResponseDto>> getMapStockmons(/*@Valid @RequestBody GetWorldStockmonsRequestDto getWorldStockmonsRequestDto*/) {
-        List<World> worlds = worldService.getNearWorlds();
-        List<StockTower> stockTowers = stockTowerService.getNearStockTowers();
+    public ResponseEntity<SuccessResponse<GetWorldStockmonsResponseDto>> getMapStockmons(@Valid @RequestBody GetWorldStockmonsRequestDto getWorldStockmonsRequestDto) {
+        List<World> worlds = worldService.getNearWorlds(getWorldStockmonsRequestDto);
+        List<StockTower> stockTowers = stockTowerService.getNearStockTowers(getWorldStockmonsRequestDto);
         List<WorldStockmonDto> worldStockmonDtos = new ArrayList<>();
         if(worlds != null) {
             for (World world : worlds) {
                 Stockmon stockmon = stockmonService.getStockmon(world.getStockmonId());
-                WorldStockmonDto worldStockmonDto = new WorldStockmonDto(world.getId(), stockmon.getImgUrl(),
+                WorldStockmonDto worldStockmonDto = new WorldStockmonDto(world.getId(), stockmon.getId(),
                         world.getLatitude(), world.getLongitude());
                 worldStockmonDtos.add(worldStockmonDto);
             }
@@ -55,4 +55,5 @@ public class WorldController {
                         .timestamp(new Date())
                 .build());
     }
+
 }

--- a/core/src/main/java/com/pda/core/dto/GetWorldStockmonsRequestDto.java
+++ b/core/src/main/java/com/pda/core/dto/GetWorldStockmonsRequestDto.java
@@ -5,11 +5,10 @@ import jakarta.validation.constraints.DecimalMin;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import static com.pda.core.utils.WorldConstants.MAX_LATITUDE_STRING;
-import static com.pda.core.utils.WorldConstants.MAX_LONGITUDE_STRING;
-import static com.pda.core.utils.WorldConstants.MIN_LATITUDE_STRING;
+import java.math.BigDecimal;
+
 import static com.pda.core.exception.ExceptionMessage.OUT_OF_WORLD_RANGE;
-import static com.pda.core.utils.WorldConstants.MIN_LONGITUDE_STRING;
+import static com.pda.core.utils.WorldConstants.*;
 
 @Getter
 @RequiredArgsConstructor
@@ -17,10 +16,10 @@ public class GetWorldStockmonsRequestDto {
 
     @DecimalMin(value = MIN_LATITUDE_STRING, message = OUT_OF_WORLD_RANGE)
     @DecimalMax(value = MAX_LATITUDE_STRING, message = OUT_OF_WORLD_RANGE)
-    private final double latitude;
+    private final BigDecimal latitude;
 
-    @DecimalMax(value = MIN_LONGITUDE_STRING, message =  OUT_OF_WORLD_RANGE)
-    @DecimalMin(value = MAX_LONGITUDE_STRING, message =  OUT_OF_WORLD_RANGE)
-    private final double longitude;
+    @DecimalMin(value = MIN_LONGITUDE_STRING, message = OUT_OF_WORLD_RANGE)
+    @DecimalMax(value = MAX_LONGITUDE_STRING, message = OUT_OF_WORLD_RANGE)
+    private final BigDecimal longitude;
 
 }

--- a/core/src/main/java/com/pda/core/dto/WorldStockmonDto.java
+++ b/core/src/main/java/com/pda/core/dto/WorldStockmonDto.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WorldStockmonDto {
     private final long id;
-    private final String imgUrl;
+    private final long stockmon_id;
     private final double latitude;
     private final double longitude;
 }

--- a/core/src/main/java/com/pda/core/entity/Stock.java
+++ b/core/src/main/java/com/pda/core/entity/Stock.java
@@ -1,16 +1,9 @@
 package com.pda.core.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,9 +30,6 @@ public class Stock {
 
     private  LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "stock")
-    @JsonIgnoreProperties("stock")
-    private List<Stockmon> stockmons = new ArrayList<>();
 
     public Stock(long id, String name, String code, StockType stockType, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;

--- a/core/src/main/java/com/pda/core/entity/World.java
+++ b/core/src/main/java/com/pda/core/entity/World.java
@@ -1,21 +1,37 @@
 package com.pda.core.entity;
 
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.Date;
+
+import lombok.*;
+import org.springframework.cglib.core.Local;
 
 @Getter
-@NoArgsConstructor
+@Builder
 @AllArgsConstructor
 public class World {
 
-    private  Long id;
-    private  Double latitude;
-    private  Double longitude;
-    private  Long stockmonId;
-    private  Boolean isCaught;
-//    private LocalDateTime createdAt;
-//    private LocalDateTime updatedAt;
+    private Long id;
+    private Double latitude;
+    private Double longitude;
+    private Long stockmonId;
+    private Boolean isCaught;
 
+    private Date createdAt;
+    private Date updatedAt;
+
+    public World(Long id, Double latitude, Double longitude, Long stockmonId, Boolean isCaught) {
+        long currentTimeMillis = System.currentTimeMillis();
+
+        this.id = id;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.stockmonId = stockmonId;
+        this.isCaught = isCaught;
+        createdAt = new Date(currentTimeMillis);
+        updatedAt = new Date(currentTimeMillis);
+    }
+
+    public World() {
+    }
 }

--- a/core/src/main/java/com/pda/core/repository/RedisRepository.java
+++ b/core/src/main/java/com/pda/core/repository/RedisRepository.java
@@ -1,0 +1,48 @@
+package com.pda.core.repository;
+
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class RedisRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ListOperations<String, Object> listOps;
+
+    public RedisRepository(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+        this.listOps = redisTemplate.opsForList();
+    }
+
+    public void pushToList(String key, Object value) {
+        listOps.rightPush(key, value);
+    }
+
+    public void setToListAll(String key, List<?> value) {
+        redisTemplate.delete(key);
+        listOps.rightPushAll(key, value);
+    }
+
+    public List<Object> getList(String key) {
+        return listOps.range(key, 0, -1);
+    }
+
+    public void setValueAtIndex(String key, long index, Object value) {
+        listOps.set(key, index, value);
+    }
+
+    public void removeFromList(String key, long count, Object value) {
+        listOps.remove(key, count, value);
+    }
+
+    public Object getFromList(String key, long index) {
+        return listOps.index(key, index);
+    }
+
+    public Long getListSize(String key) {
+        return listOps.size(key);
+    }
+}

--- a/core/src/main/java/com/pda/core/service/StockTowerService.java
+++ b/core/src/main/java/com/pda/core/service/StockTowerService.java
@@ -1,6 +1,7 @@
 package com.pda.core.service;
 
 
+import com.pda.core.dto.GetWorldStockmonsRequestDto;
 import com.pda.core.entity.StockTower;
 import com.pda.core.repository.StockTowerRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,8 @@ public class StockTowerService {
 
     private final StockTowerRepository stockTowerRepository;
 
-    public List<StockTower> getNearStockTowers() {
+    public List<StockTower> getNearStockTowers(GetWorldStockmonsRequestDto getWorldStockmonsRequestDto) {
+
         return stockTowerRepository.findAll();
     }
 }

--- a/core/src/main/java/com/pda/core/service/WorldService.java
+++ b/core/src/main/java/com/pda/core/service/WorldService.java
@@ -1,25 +1,135 @@
 package com.pda.core.service;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.pda.core.dto.GetWorldStockmonsRequestDto;
 import com.pda.core.entity.World;
+import com.pda.core.repository.RedisRepository;
+import com.pda.core.utils.RandomUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+
+import static com.pda.core.utils.WorldConstants.*;
 
 @Service
 @RequiredArgsConstructor
 public class WorldService {
 
-//    private final WorldRepository worldRepository;
+    private final RedisRepository redisRepository;
+    private final int MAX_LNG = (int) ((Double.parseDouble(MAX_LONGITUDE_STRING) - Double.parseDouble(MIN_LONGITUDE_STRING)) / STOCKMON_LONGITUDE_DIFF);
+    private final int[] dIndex = {
+            -MAX_LNG, -MAX_LNG - 1, -MAX_LNG + 1,
+            0, -1, 1,
+            MAX_LNG, MAX_LNG - 1, MAX_LNG + 1};
 
-    public List<World> getNearWorlds() {
 
-        // todo: 근처 계산하는 로직 Redis 연결 후 JPQL로 작성하기
-//        List<World> worlds = worldRepository.findAll();
-//
-//        return worlds;
+    public List<World> getNearWorlds(GetWorldStockmonsRequestDto getWorldStockmonsRequestDto) {
+        List<World> list = (List<World>) redisRepository.getList(WORLD_REDIS_KEY).get(0);
 
-        return null;
+        BigDecimal latitude = getWorldStockmonsRequestDto.getLatitude();
+        BigDecimal longitude = getWorldStockmonsRequestDto.getLongitude();
+
+        BigDecimal stockmonLatitudeDiff = BigDecimal.valueOf(STOCKMON_LATITUDE_DIFF);
+        BigDecimal stockmonLongitudeDiff = BigDecimal.valueOf(STOCKMON_LONGITUDE_DIFF);
+        BigDecimal stockmonLatitudeMin = BigDecimal.valueOf(Double.parseDouble(MIN_LATITUDE_STRING));
+        BigDecimal stockmonLongitudeMin = BigDecimal.valueOf(Double.parseDouble(MIN_LONGITUDE_STRING));
+
+        int userLat = latitude
+                .subtract(stockmonLatitudeMin)
+                .divide(stockmonLatitudeDiff, RoundingMode.HALF_UP)
+                .intValue();
+        int userLng = longitude
+                .subtract(stockmonLongitudeMin)
+                .divide(stockmonLongitudeDiff, RoundingMode.HALF_UP)
+                .intValue();
+
+        int index = userLat * MAX_LNG + userLng;
+        List<World> newList = new ArrayList<>();
+
+        for (int i = 0; i < dIndex.length; i++) {
+            int idx = index + dIndex[i];
+            if (validIndex(idx, list.size())) newList.add(list.get(idx));
+        }
+
+        return newList;
     }
+
+    private boolean validIndex(int index, int max) {
+        if(index > max || index < 0) return false;
+        return true;
+    }
+
+    @Scheduled(cron = "0 * * * * *")
+    public void setWorld() throws JsonProcessingException {
+        List<Object> list = new ArrayList<>();
+        long count = 0;
+        double latitude = Double.parseDouble(MIN_LATITUDE_STRING);
+        double nextLatitude = Double.parseDouble(MIN_LATITUDE_STRING) + STOCKMON_LATITUDE_DIFF;
+
+        for(int i = 1; nextLatitude <= Double.parseDouble(MAX_LATITUDE_STRING); i++) {
+
+            double longitude = Double.parseDouble(MIN_LONGITUDE_STRING);
+            double nextLongitude = Double.parseDouble(MIN_LONGITUDE_STRING) + STOCKMON_LONGITUDE_DIFF;
+            for(int j = 1; nextLongitude <= Double.parseDouble(MAX_LONGITUDE_STRING); j++ ) {
+                long currentTimeMillis = System.currentTimeMillis();
+
+                World newWorld = World.builder()
+                        .id(count++)
+                        .latitude(RandomUtils.createRandomDouble(latitude, nextLatitude))
+                        .longitude(RandomUtils.createRandomDouble(longitude, nextLongitude))
+                        .createdAt(new Date(currentTimeMillis))
+                        .updatedAt(new Date(currentTimeMillis))
+                        .isCaught(false)
+                        .stockmonId(RandomUtils.createRandomInt(1, 58))
+                        .build();
+
+                list.add(newWorld);
+
+                longitude = nextLongitude;
+                nextLongitude = Double.parseDouble(MIN_LONGITUDE_STRING) + (j + 1) * STOCKMON_LONGITUDE_DIFF;
+            }
+            latitude = nextLatitude;
+            nextLatitude = Double.parseDouble(MIN_LATITUDE_STRING) + (i + 1) * STOCKMON_LATITUDE_DIFF;
+
+        }
+        redisRepository.setToListAll(WORLD_REDIS_KEY, list);
+    }
+
+    @Scheduled(cron = "0 * * * * *")
+    public void reGenerate() throws JsonProcessingException {
+        List<World> list = (List<World>) redisRepository.getList(WORLD_REDIS_KEY).get(0);
+        boolean isChanged = false;
+        for(int i = 0; i < list.size(); i++) {
+            World world = list.get(i);
+
+            if(world.getIsCaught()) {
+                isChanged = true;
+                long currentTimeMillis = System.currentTimeMillis();
+                World newWorld = World.builder()
+                        .id(world.getId())
+                        .latitude(RandomUtils.createRandomDouble(Double.parseDouble(MIN_LATITUDE_STRING) + i * STOCKMON_LATITUDE_DIFF,
+                                Double.parseDouble(MIN_LATITUDE_STRING) + (i + 1) * STOCKMON_LATITUDE_DIFF))
+                        .longitude(RandomUtils.createRandomDouble(Double.parseDouble(MIN_LONGITUDE_STRING) + i * STOCKMON_LONGITUDE_DIFF,
+                                Double.parseDouble(MIN_LONGITUDE_STRING) + (i + 1) * STOCKMON_LONGITUDE_DIFF))
+                        .createdAt(world.getCreatedAt())
+                        .updatedAt(new Date(currentTimeMillis))
+                        .isCaught(false)
+                        .stockmonId(RandomUtils.createRandomInt(1, 58))
+                        .build();
+                list.set(i, newWorld);
+            }
+
+        }
+
+        if(isChanged) redisRepository.setToListAll(WORLD_REDIS_KEY, list);
+    }
+
+
 }

--- a/core/src/main/java/com/pda/core/utils/RandomUtils.java
+++ b/core/src/main/java/com/pda/core/utils/RandomUtils.java
@@ -1,0 +1,16 @@
+package com.pda.core.utils;
+
+import java.util.Random;
+
+public class RandomUtils {
+
+    private static final Random random = new Random();
+
+    public static double createRandomDouble(double min, double max) {
+        return min + (max - min) * random.nextDouble();
+    }
+
+    public static long createRandomInt(int min, int max) {
+        return (int) (Math.random() * max) + min;
+    }
+}

--- a/core/src/main/java/com/pda/core/utils/WorldConstants.java
+++ b/core/src/main/java/com/pda/core/utils/WorldConstants.java
@@ -2,9 +2,13 @@ package com.pda.core.utils;
 
 public class WorldConstants {
 
+    public static final String WORLD_REDIS_KEY = "world";
     public static final String MIN_LATITUDE_STRING = "37.42928001105901";
     public static final String MAX_LATITUDE_STRING = "37.73892900008836";
     public static final String MIN_LONGITUDE_STRING = "126.76605328501563";
     public static final String MAX_LONGITUDE_STRING = "127.21925741327027";
+
+    public static final double STOCKMON_LATITUDE_DIFF = 0.0016;
+    public static final double STOCKMON_LONGITUDE_DIFF = 0.001;
 
 }

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -1,6 +1,13 @@
 spring.application.name=core
 
+server.port=8082
+
+springdoc.swagger-ui.path=/api/swagger
+springdoc.api-docs.path=/api/docs
+
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.main.allow-bean-definition-overriding=true
+
 spring.datasource.url=${DB_HOST}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}

--- a/stock/src/main/resources/application.properties
+++ b/stock/src/main/resources/application.properties
@@ -2,3 +2,4 @@ spring.application.name=stock
 
 stock.app.sercret = ${APP_SECRET}
 stock.app.key = ${APP_KEY}
+server.port=8081


### PR DESCRIPTION
## 변경 사항 요약
> 요약 내용 나열 + (이미지)
### do
- [x] 주변 스톡몬 조회 기능 구현
- [x] 맵 더미 데이터 생성

### todo
- [ ] 특정 범위 시 두 배 확률로 등장하도록 설정
- [ ] 스톡 타워 더미 데이터 생성
- [ ] 주변 스톡타워 조회 기능 구현

![image](https://github.com/user-attachments/assets/da60e116-b246-4987-8ec5-61c1796c1079)
![image](https://github.com/user-attachments/assets/29c6ca74-afc0-494e-a180-36232320bcbb)

## 이슈 번호
- close #3 
