### PR TITLE
[FEAT] 실제 주식 교환 요청 API 작성

### DIFF
--- a/core/src/main/java/com/pda/core/controller/AccountController.java
+++ b/core/src/main/java/com/pda/core/controller/AccountController.java
@@ -2,6 +2,7 @@ package com.pda.core.controller;
 
 import com.pda.commons.dto.SuccessResponse;
 import com.pda.core.dto.AccountCheckResponseDto;
+import com.pda.core.dto.ChangeRealStockRequestDto;
 import com.pda.core.entity.Account;
 import com.pda.core.service.AccountService;
 import java.util.Date;
@@ -17,7 +18,7 @@ import static com.pda.core.config.SwaggerConfig.TRAVELER_ID;
 
 @RestController
 @Tag(name = "계좌 관련 API 모음")
-@RequestMapping("/api/core/users/account")
+@RequestMapping("/api/core")
 public class AccountController {
     private final AccountService accountService;
 
@@ -28,7 +29,7 @@ public class AccountController {
 
     @Operation(summary = "계좌 개설 API")
     @SecurityRequirement(name = JWT)
-    @PostMapping
+    @PostMapping("/users/account")
     public ResponseEntity<SuccessResponse<Void>> createAccount(@RequestHeader(TRAVELER_ID) Long travelerId) {
         Account createdAccount = accountService.createAccount(travelerId);
 
@@ -43,7 +44,7 @@ public class AccountController {
 
     @Operation(summary = "계좌 개설 여부 API")
     @SecurityRequirement(name = JWT)
-    @GetMapping
+    @GetMapping("/users/account")
     public ResponseEntity<SuccessResponse<AccountCheckResponseDto>> checkAccount(@RequestHeader(TRAVELER_ID) Long travelerId) {
         AccountCheckResponseDto checkResult = accountService.hasAccount(travelerId);
 
@@ -54,5 +55,16 @@ public class AccountController {
                 .build();
 
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "실제 주식 교환 요청 API")
+    @SecurityRequirement(name = JWT)
+    @PostMapping("/stocks/exchange")
+    public ResponseEntity<SuccessResponse<Object>> checkOut(@RequestHeader(TRAVELER_ID) Long travelerId, @RequestBody ChangeRealStockRequestDto changeRealStockRequestDto) {
+        accountService.changeRealStock(travelerId, changeRealStockRequestDto.getStockCode());
+        return ResponseEntity.ok(SuccessResponse.builder()
+                        .message("주식 획득")
+                        .timestamp(new Date())
+                .data(null).build());
     }
 }

--- a/core/src/main/java/com/pda/core/controller/TravelerStockmonController.java
+++ b/core/src/main/java/com/pda/core/controller/TravelerStockmonController.java
@@ -80,9 +80,9 @@ public class TravelerStockmonController {
     }
 
     @PostMapping("/stockmons")
+    @Operation(summary = "스톡몬 포획")
+    @SecurityRequirement(name = JWT)
     public ResponseEntity<SuccessResponse<CatchStockmonResponseDto>> catchStockmon(@RequestHeader(TRAVELER_ID) Long travelerId, @RequestBody CatchStockmonRequestDto catchStockmonRequestDto) {
-
-
         CatchStockmonResponseDto catchStockmonResponseDto = travelerStockmonService.updateCatchStockmon(travelerId, catchStockmonRequestDto);
 
         return ResponseEntity.ok()

--- a/core/src/main/java/com/pda/core/dto/CatchStockmonResponseDto.java
+++ b/core/src/main/java/com/pda/core/dto/CatchStockmonResponseDto.java
@@ -14,13 +14,18 @@ import lombok.NoArgsConstructor;
 public class CatchStockmonResponseDto {
 
     private Long stockmonId;
+    private String stockCode;
     private String stockmonName;
-    private String stockType;
+    private String description;
+    private Long stockType;
+    private String stockTypeName;
     private Long stockPrice;
     private Long stockTotalPrice;
     private String stockMarket;
 
     public static CatchStockmonResponseDto fromEntity(Stockmon stockmon, Long stockCurrentPrice, Long stockTotalPrice) {
-        return new CatchStockmonResponseDto(stockmon.getId(), stockmon.getName(), stockmon.getStock().getStockType().getName(), stockCurrentPrice,stockTotalPrice, stockmon.getStock().getStockMarket());
+        return new CatchStockmonResponseDto(stockmon.getId(), stockmon.getStock().getCode(), stockmon.getName(), stockmon.getDescription(),
+                stockmon.getStock().getStockType().getId(), stockmon.getStock().getStockType().getName(),
+                stockCurrentPrice,stockTotalPrice, stockmon.getStock().getStockMarket());
     }
 }

--- a/core/src/main/java/com/pda/core/dto/ChangeRealStockRequestDto.java
+++ b/core/src/main/java/com/pda/core/dto/ChangeRealStockRequestDto.java
@@ -1,0 +1,12 @@
+package com.pda.core.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChangeRealStockRequestDto {
+    private String stockCode;
+}

--- a/core/src/main/java/com/pda/core/entity/Account.java
+++ b/core/src/main/java/com/pda/core/entity/Account.java
@@ -1,11 +1,8 @@
 package com.pda.core.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,9 +27,24 @@ public class Account {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    @OneToOne(mappedBy = "account")
+    @JsonIgnoreProperties("account")
+    private Traveler traveler;
+
     @OneToMany(mappedBy = "account")
     @JsonIgnoreProperties("account")
     @Builder.Default
     private List<AccountStock> accountStocks = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 
 }

--- a/core/src/main/java/com/pda/core/entity/AccountStock.java
+++ b/core/src/main/java/com/pda/core/entity/AccountStock.java
@@ -1,15 +1,16 @@
 package com.pda.core.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class AccountStock {
 
@@ -30,5 +31,16 @@ public class AccountStock {
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 
 }

--- a/core/src/main/java/com/pda/core/exception/NoAccountException.java
+++ b/core/src/main/java/com/pda/core/exception/NoAccountException.java
@@ -1,0 +1,12 @@
+package com.pda.core.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NoAccountException extends CoreException{
+
+    private static final String NO_ACCOUNT = "일치하는 계좌 없음";
+
+    public NoAccountException() {
+        super(HttpStatus.BAD_REQUEST, NO_ACCOUNT);
+    }
+}

--- a/core/src/main/java/com/pda/core/exception/NoStockException.java
+++ b/core/src/main/java/com/pda/core/exception/NoStockException.java
@@ -1,0 +1,11 @@
+package com.pda.core.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NoStockException extends CoreException{
+
+    private static final String NO_STOCK = "일치하는 주식 없음";
+    public NoStockException() {
+        super(HttpStatus.BAD_REQUEST, NO_STOCK);
+    }
+}

--- a/core/src/main/java/com/pda/core/repository/AccountRepository.java
+++ b/core/src/main/java/com/pda/core/repository/AccountRepository.java
@@ -4,7 +4,10 @@ import com.pda.core.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
     boolean existsById(Long id);
+    Optional<Account> findByTravelerId(Long id);
 }

--- a/core/src/main/java/com/pda/core/repository/AccountStockRepository.java
+++ b/core/src/main/java/com/pda/core/repository/AccountStockRepository.java
@@ -1,0 +1,20 @@
+package com.pda.core.repository;
+
+import com.pda.core.entity.AccountStock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccountStockRepository extends JpaRepository<AccountStock, Long> {
+
+    Boolean existsAccountStockByAccountIdAndStockId(Long accountId, Long stockId);
+
+    @Modifying
+    @Query("UPDATE AccountStock acs SET acs.stockCount = acs.stockCount + :stockCount " +
+            "WHERE acs.account.id = :accountId and acs.stock.id = :stockId")
+    void updateStock(@Param("accountId") Long accountId, @Param("stockId") Long stockId, @Param("stockCount") Double stockCount);
+
+}

--- a/core/src/main/java/com/pda/core/repository/StockRepository.java
+++ b/core/src/main/java/com/pda/core/repository/StockRepository.java
@@ -4,6 +4,10 @@ import com.pda.core.entity.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface StockRepository extends JpaRepository<Stock, Long> {
+
+    Optional<Stock> findByCode(String code);
 }

--- a/core/src/main/java/com/pda/core/service/AccountService.java
+++ b/core/src/main/java/com/pda/core/service/AccountService.java
@@ -1,27 +1,38 @@
 package com.pda.core.service;
 
 
+import com.pda.core.client.StockFeignClient;
 import com.pda.core.dto.AccountCheckResponseDto;
 import com.pda.core.dto.AccountDto;
 import com.pda.core.dto.HasAccountResponseDto;
 import com.pda.core.entity.Account;
+import com.pda.core.entity.AccountStock;
+import com.pda.core.entity.Stock;
 import com.pda.core.entity.Traveler;
 import com.pda.core.exception.HasAccountException;
+import com.pda.core.exception.NoAccountException;
+import com.pda.core.exception.NoStockException;
 import com.pda.core.exception.NoTravelerException;
 import com.pda.core.repository.AccountRepository;
+import com.pda.core.repository.AccountStockRepository;
+import com.pda.core.repository.StockRepository;
 import com.pda.core.repository.TravelerRepository;
 import java.util.UUID;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class AccountService {
     private final AccountRepository accountRepository;
     private final TravelerRepository travelerRepository;
+    private final StockFeignClient stockFeignClient;
+    private final AccountStockRepository accountStockRepository;
 
-    public AccountService(AccountRepository accountRepository, TravelerRepository travelerRepository){
-        this.accountRepository=accountRepository;
-        this.travelerRepository=travelerRepository;
-    }
+    private static final Integer STANDARD_PRICE = 1000;
+    private final StockRepository stockRepository;
 
     public Account createAccount(Long travelerId){
         Traveler traveler = travelerRepository.findById(travelerId)
@@ -61,6 +72,25 @@ public class AccountService {
     private String generateAccountNumber() {
         // TODO: 어떤 형식으로 계좌를 발급할지 고민
         return "000-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    @Transactional
+    public void changeRealStock(Long travelerId, String code) {
+        long currentPrice = stockFeignClient.getCurrentPrice(code).getBody();
+        double stockCount = 1.0 / (double) (currentPrice / STANDARD_PRICE);
+
+        Stock stock = stockRepository.findByCode(code).orElseThrow(NoStockException::new);
+        Account account = accountRepository.findByTravelerId(travelerId).orElseThrow(NoAccountException::new);
+
+        if(accountStockRepository.existsAccountStockByAccountIdAndStockId(account.getId(), stock.getId())) {
+            accountStockRepository.updateStock(account.getId(), stock.getId(), stockCount);
+        } else {
+            accountStockRepository.save(AccountStock.builder()
+                            .account(account)
+                            .stock(stock)
+                            .stockCount(stockCount)
+                    .build());
+        }
     }
 
 }

--- a/core/src/main/java/com/pda/core/service/TravelerService.java
+++ b/core/src/main/java/com/pda/core/service/TravelerService.java
@@ -10,6 +10,7 @@ import com.pda.core.exception.DuplicateTravelerException;
 import com.pda.core.exception.NoTravelerException;
 import com.pda.core.repository.TravelerRepository;
 import jakarta.transaction.Transactional;
+
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class TravelerService {
     private final TravelerRepository travelerRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private static final long INVITER_PRESENT = 20;
+    private static final long MAX_BALL = 50;
 
     @Transactional
     public Optional<GetTravelerNicknameResponseDto> findTravelerByNickname(String nickname) {
@@ -45,9 +47,10 @@ public class TravelerService {
 
         Traveler traveler = travelerRepository.save(joinRequestDTO.toEntity(bCryptPasswordEncoder));
 
-        // TODO : 일단 초대인 보상으로 스톡볼 20개 더 주는 걸로 하긴 했는데.. 얘기 좀 더 해봐야할 듯
         if(inviterNickname != null) {
-                travelerRepository.addStockball(inviterNickname, INVITER_PRESENT);
+                travelerRepository.findByNickname(inviterNickname).ifPresent(traveler1 -> {
+                    travelerRepository.addStockball(inviterNickname, Math.min(INVITER_PRESENT, MAX_BALL - traveler1.getStockballCount()));
+                });
         }
         return JoinResponseDto.fromEntity(traveler);
     }

--- a/stock/src/main/java/com/pda/stock/dto/StockChartResponseDto.java
+++ b/stock/src/main/java/com/pda/stock/dto/StockChartResponseDto.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class StockChartResponseDto {
-    private String date;
+    private String time;
     private Long value;
 }

--- a/stock/src/main/java/com/pda/stock/service/KISService.java
+++ b/stock/src/main/java/com/pda/stock/service/KISService.java
@@ -44,7 +44,7 @@ public class KISService {
             String date = output.getDate();
 
             stockChartResponseDtos.add(StockChartResponseDto.builder()
-                    .date(date.substring(0,4) + "-" + date.substring(4,6) + "-" + date.substring(6))
+                    .time(date.substring(0,4) + "-" + date.substring(4,6) + "-" + date.substring(6))
                     .value(Long.parseLong(output.getValue()))
                     .build());
 


### PR DESCRIPTION
## 변경 사항 요약
> 요약 내용 나열 + (이미지)
- [x] 실제 주식 교환 요청 API 구현
- [x] TravelerId로 Account 가져오는 쿼리 작성
- [x] 이미 있는 경우 업데이트 없는 경우 새로 생성
- [x] StockId 가져오는 쿼리 작성
- [x] Stock Id와 Account Id로 Account_Stock이 있는 지 확인하는 쿼리 작성

![image](https://github.com/user-attachments/assets/72790ecb-8beb-4eb9-a265-230d7a21b1df)


## 이슈 번호
- close #72
