### PR TITLE
[Fix] 동맹 관련 API 응답 데이터 수정 #71

### DIFF
--- a/core/src/main/java/com/pda/core/dto/alliance/GetTravelerAllianceListResponseDto.java
+++ b/core/src/main/java/com/pda/core/dto/alliance/GetTravelerAllianceListResponseDto.java
@@ -1,17 +1,7 @@
 package com.pda.core.dto.alliance;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class GetTravelerAllianceListResponseDto {
-    private Long travelerId;
-    private String nickName;
-
-    public static GetTravelerAllianceListResponseDto fromEntity(Long travelerId, String nickName) {
-        return new GetTravelerAllianceListResponseDto(travelerId, nickName);
-    }
+public interface GetTravelerAllianceListResponseDto {
+    Long getId();
+    String getNickname();
 }

--- a/core/src/main/java/com/pda/core/entity/AllianceNotice.java
+++ b/core/src/main/java/com/pda/core/entity/AllianceNotice.java
@@ -27,6 +27,7 @@ public class AllianceNotice {
     @JoinColumn(name = "receiver_id")
     private Traveler receiver;
 
+    @JoinColumn(name = "created_at")
     private LocalDateTime createdAt;
 
 }

--- a/core/src/main/java/com/pda/core/repository/AllianceNoticeRepository.java
+++ b/core/src/main/java/com/pda/core/repository/AllianceNoticeRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Repository
 public interface AllianceNoticeRepository extends JpaRepository<AllianceNotice,Long> {
 
-    @Query("SELECT an.id AS noticeId, t.nickname AS nickName, an.createdAt AS createAt " +
+    @Query("SELECT an.id AS noticeId, t.nickname AS nickName, an.createdAt AS createdAt " +
             "FROM AllianceNotice an " +
             "JOIN Traveler t ON an.sender.id = t.id " +
             "WHERE an.receiver.id = :travelerId")

--- a/core/src/main/java/com/pda/core/repository/TravelerAllianceRepository.java
+++ b/core/src/main/java/com/pda/core/repository/TravelerAllianceRepository.java
@@ -2,6 +2,7 @@ package com.pda.core.repository;
 
 import com.pda.core.dto.alliance.GetTravelerAllianceListResponseDto;
 import com.pda.core.entity.TravelerAlliance;
+import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -12,28 +13,10 @@ import java.util.Optional;
 @Repository
 public interface TravelerAllianceRepository extends JpaRepository<TravelerAlliance, Long> {
 
-    @Query("SELECT DISTINCT t.id, t.nickname FROM TravelerAlliance ta1 " +
+    @Query("SELECT DISTINCT t.id AS id, t.nickname AS nickname FROM TravelerAlliance ta1 " +
             "JOIN TravelerAlliance ta2 ON ta1.alliance.id = ta2.alliance.id " +
             "AND ta1.traveler.id <> ta2.traveler.id " +
             "JOIN Traveler t ON ta2.traveler.id = t.id " +
             "WHERE ta1.traveler.id = :id")
-    List<Object[]> findTravelerAllianceDataByTravelerId(Long id);
-
-    default Optional<List<GetTravelerAllianceListResponseDto>> findNicknamesByAllianceId(Long id) {
-        List<Object[]> results = findTravelerAllianceDataByTravelerId(id);
-
-        if (results.isEmpty()) {
-            return Optional.empty();
-        }
-
-        List<GetTravelerAllianceListResponseDto> dtos = results.stream()
-                .map(result -> new GetTravelerAllianceListResponseDto(
-                        ((Number) result[0]).longValue(), // travelerId
-                        (String) result[1] // nickname
-                ))
-                .distinct()  // 중복 제거
-                .toList();
-
-        return Optional.of(dtos);
-    }
+    Optional<List<GetTravelerAllianceListResponseDto>> findTravelerAllianceDataByTravelerId(@Param("id") Long id);
 }

--- a/core/src/main/java/com/pda/core/service/AllianceService.java
+++ b/core/src/main/java/com/pda/core/service/AllianceService.java
@@ -37,7 +37,8 @@ public class AllianceService {
 
     @Transactional
     public List<GetTravelerAllianceListResponseDto> getAlliances(Long travelerId){
-        List<GetTravelerAllianceListResponseDto> travelerAllianceList = travelerAllianceRepository.findNicknamesByAllianceId(travelerId).orElseThrow();
+        List<GetTravelerAllianceListResponseDto> travelerAllianceList =
+                travelerAllianceRepository.findTravelerAllianceDataByTravelerId(travelerId).orElseThrow();
 
 
         return travelerAllianceList;


### PR DESCRIPTION
## 변경 사항 요약
- 동맹 목록 조회 API 호출시 동맹이 없을 경우 빈 배열로 응답되게 수정
![image](https://github.com/user-attachments/assets/c4956b0e-60d7-43e7-8a28-fc2007892380)


- 동맹 요청 조회 API 응답데이터에 created_at 컬럼추가 
![image](https://github.com/user-attachments/assets/8f5ac486-9a50-4885-b5db-a7a1c3d1cbde)


## 이슈 번호
- close #71
