### PR TITLE
스톡몬 상세 조회 API 전일 종가 추가

### DIFF
--- a/core/src/main/java/com/pda/core/client/StockFeignClient.java
+++ b/core/src/main/java/com/pda/core/client/StockFeignClient.java
@@ -16,4 +16,7 @@ public interface StockFeignClient {
 
     @GetMapping("/current-price/{code}")
     ResponseEntity<Long> getCurrentPrice(@PathVariable("code") String code);
+
+    @GetMapping("/closed-price/{code}")
+    ResponseEntity<Long> getClosedPrice(@PathVariable("code") String code);
 }

--- a/core/src/main/java/com/pda/core/dto/GetStockmonDetailResponseDto.java
+++ b/core/src/main/java/com/pda/core/dto/GetStockmonDetailResponseDto.java
@@ -18,9 +18,10 @@ public class GetStockmonDetailResponseDto {
     private Long stockmonAveragePrice;
     private Long catchCount;
     private Long stockTotalPrice;
+    private Long stockClosedPrice;
     private String stockMarket;
 
-    public static GetStockmonDetailResponseDto from(GetStockmonDetailFromDbDto dbDto, Long totalPrice) {
+    public static GetStockmonDetailResponseDto from(GetStockmonDetailFromDbDto dbDto, Long totalPrice, Long closedPrice) {
         return GetStockmonDetailResponseDto.builder()
                 .stockmonId(dbDto.getStockmonId())
                 .stockmonName(dbDto.getStockmonName())
@@ -32,6 +33,7 @@ public class GetStockmonDetailResponseDto {
                 .stockCode(dbDto.getStockCode())
                 .stockmonAveragePrice(convertToLong(dbDto.getStockmonAveragePrice()))
                 .catchCount(dbDto.getCatchCount())
+                .stockClosedPrice(closedPrice)
                 .stockTotalPrice(totalPrice)
                 .stockMarket(dbDto.getStockMarket())
                 .build();

--- a/core/src/main/java/com/pda/core/dto/alliance_notice/AllianceNoticeDto.java
+++ b/core/src/main/java/com/pda/core/dto/alliance_notice/AllianceNoticeDto.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 
 @Getter
 @Builder
@@ -23,6 +25,7 @@ public class AllianceNoticeDto {
                 .id(id)
                 .sender(sender)
                 .receiver(receiver)
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/core/src/main/java/com/pda/core/service/StockmonService.java
+++ b/core/src/main/java/com/pda/core/service/StockmonService.java
@@ -27,7 +27,7 @@ public class StockmonService {
         GetStockmonDetailFromDbDto dbDto = stockmonRepository.findStockmonDetailById(id, travelerId)
                 .orElseThrow(NoStockmonDetailException::new);
 
-        return GetStockmonDetailResponseDto.from(dbDto, stockFeignClient.getTotalPrice(dbDto.getStockCode()).getBody());
+        return GetStockmonDetailResponseDto.from(dbDto, stockFeignClient.getTotalPrice(dbDto.getStockCode()).getBody(),stockFeignClient.getClosedPrice(dbDto.getStockCode()).getBody());
     }
 
 }

--- a/stock/src/main/java/com/pda/stock/controller/KISController.java
+++ b/stock/src/main/java/com/pda/stock/controller/KISController.java
@@ -42,4 +42,9 @@ public class KISController {
                         .build());
     }
 
+    @GetMapping("/closed-price/{code}")
+    public ResponseEntity<Long> getStockClosedPrice(@PathVariable("code") String code){
+        return ResponseEntity.ok().body(kisService.getStockClosedPrice(code));
+    }
+
 }

--- a/stock/src/main/java/com/pda/stock/dto/StockChartDto.java
+++ b/stock/src/main/java/com/pda/stock/dto/StockChartDto.java
@@ -22,6 +22,9 @@ public class StockChartDto {
 
         @JsonProperty("stck_bsop_date")
         private String date;
+
+        @JsonProperty("stck_prdy_hgpr")
+        private String closedPrice;
     }
 
 }

--- a/stock/src/main/java/com/pda/stock/service/KISService.java
+++ b/stock/src/main/java/com/pda/stock/service/KISService.java
@@ -52,4 +52,8 @@ public class KISService {
         return stockChartResponseDtos;
     }
 
+    public long getStockClosedPrice(String code){
+        return Long.parseLong(kisFeignClient.getMonthChart(code,"Bearer "+TOKEN, APP_KEY, APP_SECRET).getOutput()[0].getValue());
+    }
+
 }


### PR DESCRIPTION

## 변경 사항 요약
- 스톡몬 상세 조회 API에서 응답데이터에 전일 종가 컬럼(stockClosedPrice) 추가
![image](https://github.com/user-attachments/assets/1456f56e-4c0b-498b-9a39-0f69ed4d67ef)


## 이슈 번호
- close #70 
