### PR TITLE
동맹 목록 조회 API, 모험가 닉네임 검색 API 응답데이터 수정:  id -> travelerId로 수정 #77

### DIFF
--- a/core/src/main/java/com/pda/core/dto/GetTravelerNicknameResponseDto.java
+++ b/core/src/main/java/com/pda/core/dto/GetTravelerNicknameResponseDto.java
@@ -8,12 +8,12 @@ import lombok.Getter;
 @Builder
 public class GetTravelerNicknameResponseDto {
 
-    private Long id;
+    private Long travelerId;
     private String nickname;
 
     public static GetTravelerNicknameResponseDto fromEntity(Traveler traveler) {
         return GetTravelerNicknameResponseDto.builder()
-                .id(traveler.getId())
+                .travelerId(traveler.getId())
                 .nickname(traveler.getNickname())
                 .build();
     }

--- a/core/src/main/java/com/pda/core/dto/alliance/GetTravelerAllianceListResponseDto.java
+++ b/core/src/main/java/com/pda/core/dto/alliance/GetTravelerAllianceListResponseDto.java
@@ -2,6 +2,6 @@ package com.pda.core.dto.alliance;
 
 
 public interface GetTravelerAllianceListResponseDto {
-    Long getId();
+    Long getTravelerId();
     String getNickname();
 }

--- a/core/src/main/java/com/pda/core/repository/TravelerAllianceRepository.java
+++ b/core/src/main/java/com/pda/core/repository/TravelerAllianceRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Repository
 public interface TravelerAllianceRepository extends JpaRepository<TravelerAlliance, Long> {
 
-    @Query("SELECT DISTINCT t.id AS id, t.nickname AS nickname FROM TravelerAlliance ta1 " +
+    @Query("SELECT DISTINCT t.id AS travelerId, t.nickname AS nickname FROM TravelerAlliance ta1 " +
             "JOIN TravelerAlliance ta2 ON ta1.alliance.id = ta2.alliance.id " +
             "AND ta1.traveler.id <> ta2.traveler.id " +
             "JOIN Traveler t ON ta2.traveler.id = t.id " +


### PR DESCRIPTION
## 변경 사항 요약
- 모험가 닉네임 API 응답데이터 id -> travelerId로 수정
![image](https://github.com/user-attachments/assets/4cb80da7-5a51-4c80-8578-2495798f138d)

- 동맹 목록 조회 API 응답데이터 id -> travelerId로 수정 
![image](https://github.com/user-attachments/assets/ed4222dd-76a8-4191-92e4-382af6e96bdb)


## 이슈 번호
- close #77 
